### PR TITLE
Add logging and export PDF translation artifacts

### DIFF
--- a/OCR/paddle_ocr_func.py
+++ b/OCR/paddle_ocr_func.py
@@ -1,15 +1,23 @@
+import logging
+
+import numpy as np
 from paddleocr import PaddleOCR
-import numpy as np 
+
+
+logger = logging.getLogger(__name__)
 
 class CustomPaddle(PaddleOCR):
     def __init__(self, doc_orientation_classify_model_name=None, doc_orientation_classify_model_dir=None, doc_unwarping_model_name=None, doc_unwarping_model_dir=None, text_detection_model_name=None, text_detection_model_dir=None, textline_orientation_model_name=None, textline_orientation_model_dir=None, textline_orientation_batch_size=None, text_recognition_model_name=None, text_recognition_model_dir=None, text_recognition_batch_size=None, use_doc_orientation_classify=None, use_doc_unwarping=None, use_textline_orientation=None, text_det_limit_side_len=None, text_det_limit_type=None, text_det_thresh=None, text_det_box_thresh=None, text_det_unclip_ratio=None, text_det_input_shape=None, text_rec_score_thresh=None, return_word_box=None, text_rec_input_shape=None, lang=None, ocr_version=None, **kwargs):
         super().__init__(doc_orientation_classify_model_name, doc_orientation_classify_model_dir, doc_unwarping_model_name, doc_unwarping_model_dir, text_detection_model_name, text_detection_model_dir, textline_orientation_model_name, textline_orientation_model_dir, textline_orientation_batch_size, text_recognition_model_name, text_recognition_model_dir, text_recognition_batch_size, use_doc_orientation_classify, use_doc_unwarping, use_textline_orientation, text_det_limit_side_len, text_det_limit_type, text_det_thresh, text_det_box_thresh, text_det_unclip_ratio, text_det_input_shape, text_rec_score_thresh, return_word_box, text_rec_input_shape, lang, ocr_version, **kwargs)
     
     def predict_with_align(self, image:np.ndarray):
+        logger.debug("Starting OCR prediction")
         result = self.predict(image, use_doc_orientation_classify=True)
         bboxes = result[0]["rec_boxes"]
         texts = result[0]["rec_texts"]
-        return self.group_text_lines(bboxes, texts)
+        grouped = self.group_text_lines(bboxes, texts)
+        logger.debug("OCR prediction produced %d grouped lines", len(grouped))
+        return grouped
     
     @staticmethod
     def group_text_lines(bboxes, texts, y_tolerance=25):

--- a/main.py
+++ b/main.py
@@ -1,28 +1,90 @@
-from OCR.paddle_ocr_func import CustomPaddle
-from word.word_manager import layout_with_spaces, Document
+import logging
+import os
+from pathlib import Path
+
+import numpy as np
 from pdf2image import convert_from_path
-from translator.gemini import GeminiTranslator
 from tqdm import tqdm
-import numpy as np 
-import os 
+
+from OCR.paddle_ocr_func import CustomPaddle
+from translator.gemini import GeminiTranslator
+from word.word_manager import Document, layout_with_spaces
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(name)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 
 def main(pdf_path, out_path, poppler_path, lang="korean"):
+    pdf_path = Path(pdf_path)
+    poppler_path = Path(poppler_path) if poppler_path else None
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    ocr_output_path = out_path.with_name(f"{out_path.stem}_ocr{out_path.suffix}")
+    images_output_dir = out_path.parent / pdf_path.stem
+    images_output_dir.mkdir(parents=True, exist_ok=True)
+
+    logger.info("Starting PDF translation process for %s -> %s", pdf_path, out_path)
+
     ocr_obj = CustomPaddle(use_angle_cls=True, lang=lang)
     translator = GeminiTranslator(api_key=os.getenv("GOOGLE_API"))
-    doc = Document()
+    translated_doc = Document()
+    ocr_doc = Document()
 
-    images = convert_from_path(pdf_path, poppler_path=poppler_path)
+    try:
+        images = convert_from_path(
+            str(pdf_path), poppler_path=str(poppler_path) if poppler_path else None
+        )
+        logger.info("Converted PDF to %d images", len(images))
+    except Exception as exc:
+        logger.exception("Failed to convert PDF to images: %s", exc)
+        raise
 
-    for img in tqdm(images, desc="Page 변환중"):
-        img = np.array(img)
-        result = ocr_obj.predict_with_align(img)
-        result = translator.translate(texts=result,
-                             source_lang="Korean",
-                             target_lang="English")
-        layout_with_spaces(doc, result)
-        doc.add_page_break()
-    doc.save(out_path)
+    for index, image in enumerate(tqdm(images, desc="Page 변환중"), start=1):
+        logger.info("Processing page %d", index)
+        image_path = images_output_dir / f"page_{index:03d}.png"
+        try:
+            image.save(image_path)
+            logger.info("Saved page image to %s", image_path)
+        except Exception:
+            logger.exception("Failed to save image for page %d", index)
+
+        np_image = np.array(image)
+        try:
+            ocr_result = ocr_obj.predict_with_align(np_image)
+            logger.info("OCR completed for page %d with %d entries", index, len(ocr_result))
+        except Exception:
+            logger.exception("OCR failed for page %d", index)
+            continue
+
+        layout_with_spaces(ocr_doc, ocr_result)
+        ocr_doc.add_page_break()
+
+        try:
+            translated_result = translator.translate(
+                texts=ocr_result, source_lang="Korean", target_lang="English"
+            )
+        except Exception:
+            logger.exception("Translation raised an unexpected exception on page %d", index)
+            continue
+
+        if translated_result == "":
+            logger.error("Translation failed for page %d; skipping page", index)
+            continue
+
+        layout_with_spaces(translated_doc, translated_result)
+        translated_doc.add_page_break()
+
+    translated_doc.save(out_path)
+    logger.info("Saved translated document to %s", out_path)
+
+    ocr_doc.save(ocr_output_path)
+    logger.info("Saved OCR document to %s", ocr_output_path)
+
 
 if __name__ == "__main__":
     pdf_path = "pdfs/full.pdf"


### PR DESCRIPTION
## Summary
- add structured logging to the OCR, translation, and pipeline flows
- export intermediate PDF page images and the raw OCR layout alongside the translated document
- ensure Gemini translation errors are logged and do not block later pages

## Testing
- python -m compileall main.py OCR/paddle_ocr_func.py translator/gemini.py

------
https://chatgpt.com/codex/tasks/task_e_68e3af4d35d8832ab7fe91d37adc93f2